### PR TITLE
[Hotfix] 버튼 및 input 기본 스타일 초기화

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -10,6 +10,7 @@
   border: var(--button-border, 1.5px solid transparent);
   font-family: $font-family-primary;
   font-weight: $fw-semibold;
+  line-height: 1;
   text-decoration: none;
   white-space: nowrap;
   color: $white-3;

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -129,3 +129,36 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+button,
+input,
+optgroup,
+select,
+textarea {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+  background: transparent;
+  box-sizing: border-box;
+}
+
+button {
+  cursor: pointer;
+  outline: none;
+}
+
+/* Remove button styling */
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+}


### PR DESCRIPTION
## 🔀 PR 제목
- [Hotfix] 버튼 및 input 기본 스타일 초기화
---

## 📌 작업 내용 요약
- 버튼 및 특정 타입의 input 기본 스타일을 초기화 했습니다.
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
- 존재하지 않습니당
---

## 📎 기타 참고 사항
- button이 뭔가 이상하게 출력된다 싶어서 확인해보니, 스타일 초기화가 안 되어있었습니다.
- 나중에 수정하면 일이 복잡해질 것 같아서 hotfix로 pr 올립니당
  - 별도의 jira연동 및 이슈는 존재하지 않습니다.
- button에 line-height 적용해 두었습니당

- 별건 아니지만 중앙정렬 같은 것들이 아래와 같이 정상적으로 바뀌는데, 뭔가 이상하게 바뀌시는 분 계시다면 바로 말씀 부탁드립니다!
<img width="547" height="51" alt="image" src="https://github.com/user-attachments/assets/aab80548-23a7-45a5-89de-d0101809bcbb" />
<img width="542" height="48" alt="image" src="https://github.com/user-attachments/assets/a5fe8cfb-044e-45ef-8954-69f77f80edc5" />

