### PR TITLE
[Refactor] 개인 정보 변경 페이지 디테일 수정

### DIFF
--- a/src/features/Profile/components/edit/PersonalInfoForm.tsx
+++ b/src/features/Profile/components/edit/PersonalInfoForm.tsx
@@ -52,6 +52,13 @@ const PersonalInfoForm = ({
 
     return birthDate;
   };
+  // 비밀번호 표시 값 계산
+  const getPasswordDisplay = () => {
+    if (userInfo.isSocial) {
+      return ''; // 소셜 로그인 시 빈칸
+    }
+    return '*'.repeat(userInfo.password?.length || 8);
+  };
 
   // 읽기전용 인풋 클릭 방지
   const handleReadOnlyInputEvents = (e: React.MouseEvent | React.FocusEvent) => {
@@ -151,9 +158,9 @@ const PersonalInfoForm = ({
       {/* 비밀번호 */}
       <EditableFieldRow
         label="비밀번호"
-        value="**********"
+        value={getPasswordDisplay()}
         buttonText="비밀번호 변경"
-        inputType="password"
+        inputType="text"
         onEdit={onPasswordEdit}
         disabled={userInfo.isSocial}
       />

--- a/src/pages/edit/EditMyInfoPage/EditMyInfoPage.tsx
+++ b/src/pages/edit/EditMyInfoPage/EditMyInfoPage.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { ArrowBendUpLeftIcon } from '@phosphor-icons/react';
 import { useNavigate } from 'react-router-dom';
 
+import { getErrorMessage } from '@/api/auth';
 import Button from '@/components/Button/Button';
 import EditNicknameModal from '@/features/Profile/components/edit/modals/EditNicknameModal';
 import EditPasswordModal from '@/features/Profile/components/edit/modals/EditPasswordModal';
@@ -45,13 +46,15 @@ const EditMyInfoPage = () => {
     setShowNicknameModal(true);
   };
 
+  // 백엔드 에러 메시지 처리 추가
   const handleNicknameSave = async (nickname: string) => {
     try {
       await updateNickname(nickname);
       setShowNicknameModal(false);
     } catch (error) {
       console.error('닉네임 저장 실패:', error);
-      alert('닉네임 변경에 실패했습니다. 다시 시도해주세요.');
+      const errorMessage = getErrorMessage(error);
+      alert(errorMessage);
     }
   };
 
@@ -94,7 +97,8 @@ const EditMyInfoPage = () => {
       setPendingAction(null);
     } catch (error) {
       console.error('비밀번호 확인 실패:', error);
-      alert('비밀번호 확인 중 오류가 발생했습니다.');
+      const errorMessage = getErrorMessage(error);
+      alert(errorMessage);
     }
   };
 
@@ -109,7 +113,8 @@ const EditMyInfoPage = () => {
       setShowPhoneModal(false);
     } catch (error) {
       console.error('전화번호 저장 실패:', error);
-      alert('전화번호 변경에 실패했습니다. 다시 시도해주세요.');
+      const errorMessage = getErrorMessage(error);
+      alert(errorMessage);
     }
   };
 
@@ -119,7 +124,8 @@ const EditMyInfoPage = () => {
       setShowPasswordModal(false);
     } catch (error) {
       console.error('비밀번호 저장 실패:', error);
-      alert('비밀번호 변경에 실패했습니다. 다시 시도해주세요.');
+      const errorMessage = getErrorMessage(error);
+      alert(errorMessage);
     }
   };
 
@@ -128,7 +134,8 @@ const EditMyInfoPage = () => {
       await updateProfileImage(file);
     } catch (error) {
       console.error('프로필 이미지 변경 실패:', error);
-      alert('프로필 이미지 변경에 실패했습니다. 다시 시도해주세요.');
+      const errorMessage = getErrorMessage(error);
+      alert(errorMessage);
     }
   };
 
@@ -155,7 +162,8 @@ const EditMyInfoPage = () => {
       navigate('/auth/signin');
     } catch (error) {
       console.error('회원 탈퇴 실패:', error);
-      alert('회원 탈퇴 중 오류가 발생했습니다.');
+      const errorMessage = getErrorMessage(error);
+      alert(errorMessage);
     }
   };
 


### PR DESCRIPTION
## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.
- [x] 소셜 로그인인 경우 이메일, 전화번호와 동일하게 비밀번호도 빈칸으로 보이게 수정했습니당
<img width="963" height="480" alt="스크린샷 2025-09-13 오전 8 27 32" src="https://github.com/user-attachments/assets/2e4b6964-be2b-42f2-95ad-9aebf38c98eb" />

+추가로 에러메세지 그냥 '오류가 발생했습니다' 멘트를 출력하던 걸 오류에 따라 에러 메세지가 나오게 수정했습니당

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #135
