### PR TITLE
[Fix] div 내부 배지 수직 정렬

### DIFF
--- a/src/features/Team/components/UserRow/UserRow.module.scss
+++ b/src/features/Team/components/UserRow/UserRow.module.scss
@@ -35,6 +35,13 @@
         align-items: center;
         font-size: $fs-xxxsmall;
       }
+
+      &__badgeContainer {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+      }
     }
 
     &__right {

--- a/src/features/Team/components/UserRow/UserRow.tsx
+++ b/src/features/Team/components/UserRow/UserRow.tsx
@@ -169,6 +169,7 @@ const User = ({ user }: UserProps) => {
             <div className={styles.user__item__left__badges}>
               {user.mainBadge && (
                 <div
+                  className={styles.user__item__left__badgeContainer}
                   onMouseEnter={e =>
                     handleBadgeMouseEnter(e, 'main', {
                       type: user.mainBadge?.type as BadgeType,
@@ -176,7 +177,6 @@ const User = ({ user }: UserProps) => {
                     })
                   }
                   onMouseLeave={handleBadgeMouseLeave}
-                  style={{ display: 'inline-block' }}
                 >
                   <Badge
                     className={styles.badge}
@@ -190,6 +190,7 @@ const User = ({ user }: UserProps) => {
               )}
               {user.abandonBadge && (
                 <div
+                  className={styles.user__item__left__badgeContainer}
                   onMouseEnter={e =>
                     handleBadgeMouseEnter(e, 'abandon', {
                       count: user.abandonBadge?.count,
@@ -197,7 +198,6 @@ const User = ({ user }: UserProps) => {
                     })
                   }
                   onMouseLeave={handleBadgeMouseLeave}
-                  style={{ display: 'inline-block' }}
                 >
                   <Badge
                     className={styles.badge}

--- a/src/features/map/components/MapOverlay/MapOverlay.module.scss
+++ b/src/features/map/components/MapOverlay/MapOverlay.module.scss
@@ -63,6 +63,13 @@
     gap: 3px;
     margin-bottom: 8px;
 
+    &__badgeContainer {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+    }
+
     &__badges {
       display: flex;
       flex-direction: row;

--- a/src/features/map/components/MapOverlay/MapPlayerOverlay/MapPlayerOverlay.tsx
+++ b/src/features/map/components/MapOverlay/MapPlayerOverlay/MapPlayerOverlay.tsx
@@ -174,6 +174,7 @@ const MapPlayerOverlay: React.FC<PlayerOverlayProps> = ({ id, onOverlayClose }) 
             <div className={styles.overlay__info__core__badges}>
               {player.mainBadge && (
                 <div
+                  className={styles.overlay__info__core__badgeContainer}
                   onMouseEnter={e =>
                     handleBadgeMouseEnter(e, 'main', {
                       type: player.mainBadge?.type as BadgeType,
@@ -181,7 +182,6 @@ const MapPlayerOverlay: React.FC<PlayerOverlayProps> = ({ id, onOverlayClose }) 
                     })
                   }
                   onMouseLeave={handleBadgeMouseLeave}
-                  style={{ display: 'inline-block' }}
                 >
                   <Badge
                     className={styles.badge}
@@ -195,6 +195,7 @@ const MapPlayerOverlay: React.FC<PlayerOverlayProps> = ({ id, onOverlayClose }) 
               )}
               {player.abandonBadge && (
                 <div
+                  className={styles.overlay__info__core__badgeContainer}
                   onMouseEnter={e =>
                     handleBadgeMouseEnter(e, 'abandon', {
                       count: player.abandonBadge?.count,
@@ -202,7 +203,6 @@ const MapPlayerOverlay: React.FC<PlayerOverlayProps> = ({ id, onOverlayClose }) 
                     })
                   }
                   onMouseLeave={handleBadgeMouseLeave}
-                  style={{ display: 'inline-block' }}
                 >
                   <Badge
                     className={styles.badge}


### PR DESCRIPTION
## 📌 작업 내용 요약

- div 내에서의 Badge를 수직 정렬합니다.
- 수정된 곳: 지도 페이지의 MapPlayerOverlay, 팀 관리 페이지의 UserRow

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #163 

---

## 📸스크린샷 (선택)
<img width="808" height="200" alt="image" src="https://github.com/user-attachments/assets/a3f67ecf-9410-4f77-8842-fa83fe5ca404" />