### PR TITLE
[Fix] UserRow 드롭다운 스타일 수정

### DIFF
--- a/src/features/Team/components/UserRow/UserRow.module.scss
+++ b/src/features/Team/components/UserRow/UserRow.module.scss
@@ -81,7 +81,7 @@
   top: 100%;
   right: 0;
   z-index: 100;
-  min-width: 120px;
+  min-width: 150px;
   margin-top: 4px;
   border: 1px solid $gray-2;
   border-radius: $r-small;
@@ -90,13 +90,15 @@
 }
 
 .dropdownItem {
-  display: block;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
   width: 100%;
-  padding: 8px 12px;
+  padding: 0 12px;
   border: none;
   font-size: $fs-xxsmall;
   text-align: left;
-  color: $black-3;
+  color: $black-4;
   background: none;
   transition: background-color 0.2s ease;
   cursor: pointer;
@@ -116,4 +118,10 @@
   &:only-child {
     border-radius: $r-small;
   }
+}
+
+.iconWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/features/Team/components/UserRow/UserRow.tsx
+++ b/src/features/Team/components/UserRow/UserRow.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 
-import { DotsThreeVerticalIcon } from '@phosphor-icons/react';
+import { ChatCircleIcon, DotsThreeVerticalIcon, PaperPlaneTiltIcon } from '@phosphor-icons/react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
@@ -225,6 +225,7 @@ const User = ({ user }: UserProps) => {
                 <Button width="12" padding="0" onClick={handleDropdownToggle}>
                   <DotsThreeVerticalIcon size={20} />
                 </Button>
+
                 {isDropdownOpen && (
                   <div className={styles.dropdown}>
                     <button
@@ -236,7 +237,14 @@ const User = ({ user }: UserProps) => {
                         cursor: isDmButtonDisabled ? 'not-allowed' : 'pointer',
                       }}
                     >
-                      {dmButtonText}
+                      <div className={styles.iconWrapper}>
+                        {dmButtonText === 'DM 보내기' ? (
+                          <ChatCircleIcon size={16} />
+                        ) : (
+                          <PaperPlaneTiltIcon size={16} />
+                        )}
+                      </div>
+                      <span>{dmButtonText}</span>
                     </button>
                   </div>
                 )}
@@ -245,6 +253,7 @@ const User = ({ user }: UserProps) => {
           </div>
         </div>
       </div>
+
       {showTooltip &&
         createPortal(
           <div


### PR DESCRIPTION
## 📌 작업 내용 요약

- 팀 관리 페이지의 UserRow 드롭다운 스타일 수정 및 아이콘 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #167 

---

## 📸스크린샷 (선택)
- DM 요청하기
<img width="1881" height="1527" alt="image" src="https://github.com/user-attachments/assets/99437ccd-c34a-4dd5-a60a-9b249b2b5b07" />

- DM 요청 대기 중
<img width="1881" height="1527" alt="image" src="https://github.com/user-attachments/assets/100304cf-a763-44e2-93b6-0190fac15b08" />

- DM 보내기
<img width="1881" height="1527" alt="image" src="https://github.com/user-attachments/assets/c04f1c18-bfbb-4dac-ac63-2cf0c1915838" />
