### PR TITLE
[Feature]: 프로필 페이지 스터디, 프로젝트 조회 섹션에서 타인 클릭 시 이동 위치 수정

### DIFF
--- a/src/features/Profile/components/sections/ProjectSection.tsx
+++ b/src/features/Profile/components/sections/ProjectSection.tsx
@@ -29,8 +29,20 @@ const ProjectSection = forwardRef<HTMLElement, ProjectSectionProps>(({ user, cla
     getShowMoreText,
   } = useInfiniteLoad(user.userId, 'projects', initialProjects, user.projectsTotalItems);
 
-  const handleProjectClick = (teamId: number) => {
-    navigate(`/team/${teamId}/setting`);
+  const handleProjectClick = (projectId: number, teamId: number) => {
+    if (user.isMine) {
+      // 본인 프로필: 팀관리 페이지로 이동
+      navigate(`/team/${teamId}/setting`);
+    } else {
+      // 타인 프로필: 프로젝트 모집 공고 페이지로 이동
+      navigate(`/detail/project/${projectId}`);
+    }
+  };
+
+  const getAriaLabel = (title: string) => {
+    return user.isMine
+      ? `${title} 프로젝트 팀 관리 페이지로 이동`
+      : `${title} 프로젝트 모집 공고 보기`;
   };
 
   return (
@@ -54,8 +66,8 @@ const ProjectSection = forwardRef<HTMLElement, ProjectSectionProps>(({ user, cla
                   key={project.id}
                   type="button"
                   className={styles.projectItem}
-                  onClick={() => handleProjectClick(project.teamId)}
-                  aria-label={`${project.title} 프로젝트 팀 관리 페이지로 이동`}
+                  onClick={() => handleProjectClick(project.id, project.teamId)}
+                  aria-label={getAriaLabel(project.title)}
                 >
                   <div className={styles.projectIcon}>
                     <ShoppingBagOpenIcon size={21} weight="regular" />

--- a/src/features/Profile/components/sections/StudySection.tsx
+++ b/src/features/Profile/components/sections/StudySection.tsx
@@ -29,8 +29,18 @@ const StudySection = forwardRef<HTMLElement, StudySectionProps>(({ user, classNa
     getShowMoreText,
   } = useInfiniteLoad(user.userId, 'studies', initialStudies, user.studiesTotalItems);
 
-  const handleStudyClick = (teamId: number) => {
-    navigate(`/team/${teamId}/setting`);
+  const handleStudyClick = (studyId: number, teamId: number) => {
+    if (user.isMine) {
+      // 본인 프로필: 팀관리 페이지로 이동
+      navigate(`/team/${teamId}/setting`);
+    } else {
+      // 타인 프로필: 스터디 모집 공고 페이지로 이동
+      navigate(`/detail/study/${studyId}`);
+    }
+  };
+
+  const getAriaLabel = (title: string) => {
+    return user.isMine ? `${title} 스터디 팀 관리 페이지로 이동` : `${title} 스터디 모집 공고 보기`;
   };
 
   return (
@@ -54,8 +64,8 @@ const StudySection = forwardRef<HTMLElement, StudySectionProps>(({ user, classNa
                   key={study.id}
                   type="button"
                   className={styles.studyItem}
-                  onClick={() => handleStudyClick(study.teamId)}
-                  aria-label={`${study.title} 스터디 팀 관리 페이지로 이동`}
+                  onClick={() => handleStudyClick(study.id, study.teamId)}
+                  aria-label={getAriaLabel(study.title)}
                 >
                   <div className={styles.studyIcon}>
                     <BookBookmarkIcon size={21} weight="regular" />


### PR DESCRIPTION


## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

타인의 프로필 페이지에서 스터디, 프로젝트 조회의 목록을 클릭하면, 이동되는 페이지 위치를 수정했습니다
[ 팀 관리 페이지 ] -> [ 스터디/프로젝트 모집글 페이지 ]

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #191 


---

