### PR TITLE
[Fix] 프로필 페이지 비공개일때, 본인의 경우 보이게 수정

### DIFF
--- a/src/features/Profile/components/ProfileView.tsx
+++ b/src/features/Profile/components/ProfileView.tsx
@@ -156,29 +156,69 @@ const ProfileView = forwardRef<HTMLDivElement, ExtendedProfileViewProps>(
           </div>
         </div>
 
-        {/* 상세 정보 섹션 - 공개 상태에 따라 조건부 렌더링 */}
-        {isProfilePublic ? (
-          // 공개 프로필: 모든 정보 표시
+        {/* 상세 정보 섹션 - 본인이 아니고 비공개일 때만 숨김 */}
+        {!user.isMine && !isProfilePublic ? (
+          // 타인의 비공개 프로필: 비공개 메시지만 표시
+          <PrivateProfileMessage />
+        ) : (
+          // 본인 프로필 또는 타인의 공개 프로필: 모든 정보 표시
           <div className={styles.twoColumnLayout}>
             {/* 왼쪽 컬럼 (737px) */}
             <div className={styles.leftColumn}>
-              <LocationSection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
-              <TechStackSection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
-              <ProjectSection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
-              <StudySection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
+              <LocationSection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
+              <TechStackSection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
+              <ProjectSection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
+              <StudySection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
             </div>
 
             {/* 오른쪽 컬럼 (404px) */}
             <div className={styles.rightColumn}>
-              <PositionSection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
-              <TraitsSection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
-              <TimeSection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
-              <PortfolioSection user={user} isEditable={isEditable} onEdit={handleSectionEdit} />
+              <PositionSection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
+              <TraitsSection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
+              <TimeSection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
+              <PortfolioSection
+                user={user}
+                isEditable={isEditable}
+                onEdit={handleSectionEdit}
+                isPrivate={user.isMine && !isProfilePublic}
+              />
             </div>
           </div>
-        ) : (
-          // 비공개 프로필: 비공개 메시지만 표시
-          <PrivateProfileMessage />
         )}
       </div>
     );

--- a/src/features/Profile/components/sections/LocationSection.module.scss
+++ b/src/features/Profile/components/sections/LocationSection.module.scss
@@ -102,3 +102,22 @@
     font-size: v.$fs-xxxsmall;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/LocationSection.tsx
+++ b/src/features/Profile/components/sections/LocationSection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { PencilSimpleIcon } from '@phosphor-icons/react';
+import { LockIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 
 import ProfileMap from '@/features/map/components/ProfileMap/ProfileMap';
@@ -16,7 +16,7 @@ interface LocationSectionProps extends ProfileSectionProps {
 }
 
 const LocationSection = forwardRef<HTMLElement, LocationSectionProps>(
-  ({ user, isEditable = false, onEdit, className }, ref) => {
+  ({ user, isEditable = false, onEdit, isPrivate = false, className }, ref) => {
     const handleEdit = () => {
       if (isEditable && onEdit) {
         onEdit('location');
@@ -61,6 +61,14 @@ const LocationSection = forwardRef<HTMLElement, LocationSectionProps>(
           {/* 지도 영역 */}
           <ProfileMap playerId={user.userId} location={user.location} />
         </div>
+
+        {/* 비공개 메시지 */}
+        {isPrivate && (
+          <div className={styles.privateMessage}>
+            <LockIcon size={16} weight="regular" />
+            <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
+          </div>
+        )}
       </section>
     );
   }

--- a/src/features/Profile/components/sections/PortfolioSection.module.scss
+++ b/src/features/Profile/components/sections/PortfolioSection.module.scss
@@ -126,3 +126,22 @@
     @include m.font-tiny-text;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/PortfolioSection.tsx
+++ b/src/features/Profile/components/sections/PortfolioSection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { PencilSimpleIcon } from '@phosphor-icons/react';
+import { LockIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 
 import type { ProfileSectionProps } from '@/types/user';
@@ -15,7 +15,7 @@ interface PortfolioSectionProps extends ProfileSectionProps {
 }
 
 const PortfolioSection = forwardRef<HTMLElement, PortfolioSectionProps>(
-  ({ user, isEditable = false, onEdit, className }, ref) => {
+  ({ user, isEditable = false, onEdit, isPrivate = false, className }, ref) => {
     const handleEdit = () => {
       if (isEditable && onEdit) {
         onEdit('portfolio');
@@ -72,6 +72,14 @@ const PortfolioSection = forwardRef<HTMLElement, PortfolioSectionProps>(
             </div>
           )}
         </div>
+
+        {/* 비공개 메시지 */}
+        {isPrivate && (
+          <div className={styles.privateMessage}>
+            <LockIcon size={16} weight="regular" />
+            <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
+          </div>
+        )}
       </section>
     );
   }

--- a/src/features/Profile/components/sections/PositionSection.module.scss
+++ b/src/features/Profile/components/sections/PositionSection.module.scss
@@ -136,3 +136,22 @@
     padding: 2px 10px;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/PositionSection.tsx
+++ b/src/features/Profile/components/sections/PositionSection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { PencilSimpleIcon } from '@phosphor-icons/react';
+import { LockIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 
 import type { ProfileSectionProps } from '@/types/user';
@@ -15,7 +15,7 @@ interface PositionSectionProps extends ProfileSectionProps {
 }
 
 const PositionSection = forwardRef<HTMLElement, PositionSectionProps>(
-  ({ user, isEditable = false, onEdit, className }, ref) => {
+  ({ user, isEditable = false, onEdit, isPrivate = false, className }, ref) => {
     const handleEdit = () => {
       if (isEditable && onEdit) {
         onEdit('position');
@@ -70,6 +70,14 @@ const PositionSection = forwardRef<HTMLElement, PositionSectionProps>(
             </div>
           )}
         </div>
+
+        {/* 비공개 메시지 */}
+        {isPrivate && (
+          <div className={styles.privateMessage}>
+            <LockIcon size={16} weight="regular" />
+            <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
+          </div>
+        )}
       </section>
     );
   }

--- a/src/features/Profile/components/sections/ProjectSection.module.scss
+++ b/src/features/Profile/components/sections/ProjectSection.module.scss
@@ -195,3 +195,22 @@
     padding: 6px 12px;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/ProjectSection.tsx
+++ b/src/features/Profile/components/sections/ProjectSection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { ShoppingBagOpenIcon } from '@phosphor-icons/react';
+import { LockIcon, ShoppingBagOpenIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 
@@ -18,99 +18,111 @@ interface ProjectSectionProps extends ProfileSectionProps {
   className?: string;
 }
 
-const ProjectSection = forwardRef<HTMLElement, ProjectSectionProps>(({ user, className }, ref) => {
-  const navigate = useNavigate();
-  const initialProjects = user.projects || [];
-  const {
-    items: projects,
-    isLoading,
-    hasMore,
-    loadMore,
-    getShowMoreText,
-  } = useInfiniteLoad(user.userId, 'projects', initialProjects, user.projectsTotalItems);
+const ProjectSection = forwardRef<HTMLElement, ProjectSectionProps>(
+  ({ user, isPrivate = false, className }, ref) => {
+    const navigate = useNavigate();
+    const initialProjects = user.projects || [];
+    const {
+      items: projects,
+      isLoading,
+      hasMore,
+      loadMore,
+      getShowMoreText,
+    } = useInfiniteLoad(user.userId, 'projects', initialProjects, user.projectsTotalItems);
 
-  const handleProjectClick = (projectId: number, teamId: number) => {
-    if (user.isMine) {
-      // 본인 프로필: 팀관리 페이지로 이동
-      navigate(`/team/${teamId}/setting`);
-    } else {
-      // 타인 프로필: 프로젝트 모집 공고 페이지로 이동
-      navigate(`/detail/project/${projectId}`);
-    }
-  };
+    const handleProjectClick = (projectId: number, teamId: number) => {
+      if (user.isMine) {
+        // 본인 프로필: 팀관리 페이지로 이동
+        navigate(`/team/${teamId}/setting`);
+      } else {
+        // 타인 프로필: 프로젝트 모집 공고 페이지로 이동
+        navigate(`/detail/project/${projectId}`);
+      }
+    };
 
-  const getAriaLabel = (title: string) => {
-    return user.isMine
-      ? `${title} 프로젝트 팀 관리 페이지로 이동`
-      : `${title} 프로젝트 모집 공고 보기`;
-  };
+    const getAriaLabel = (title: string) => {
+      return user.isMine
+        ? `${title} 프로젝트 팀 관리 페이지로 이동`
+        : `${title} 프로젝트 모집 공고 보기`;
+    };
 
-  return (
-    <section
-      ref={ref}
-      className={clsx(styles.projectSection, className)}
-      aria-labelledby="project-title"
-    >
-      <div className={styles.header}>
-        <h2 id="project-title" className={styles.title}>
-          프로젝트
-        </h2>
-      </div>
+    return (
+      <section
+        ref={ref}
+        className={clsx(styles.projectSection, className)}
+        aria-labelledby="project-title"
+      >
+        <div className={styles.header}>
+          <h2 id="project-title" className={styles.title}>
+            프로젝트
+          </h2>
+        </div>
 
-      <div>
-        {projects.length > 0 ? (
-          <>
-            <div className={styles.projectList}>
-              {projects.map(project => (
-                <button
-                  key={project.id}
-                  type="button"
-                  className={styles.projectItem}
-                  onClick={() => handleProjectClick(project.id, project.teamId)}
-                  aria-label={getAriaLabel(project.title)}
-                >
-                  <div className={styles.projectIcon}>
-                    <ShoppingBagOpenIcon size={21} weight="regular" />
-                  </div>
+        <div>
+          {projects.length > 0 ? (
+            <>
+              <div className={styles.projectList}>
+                {projects.map(project => (
+                  <button
+                    key={project.id}
+                    type="button"
+                    className={styles.projectItem}
+                    onClick={() => handleProjectClick(project.id, project.teamId)}
+                    aria-label={getAriaLabel(project.title)}
+                  >
+                    <div className={styles.projectIcon}>
+                      <ShoppingBagOpenIcon size={21} weight="regular" />
+                    </div>
 
-                  <div className={styles.projectInfo}>
-                    <h3 className={styles.projectTitle}>{project.title}</h3>
-                    <p className={styles.projectDate}>
-                      {formatDateRange(project.startDate, project.endDate ?? undefined)}
-                    </p>
-                  </div>
+                    <div className={styles.projectInfo}>
+                      <h3 className={styles.projectTitle}>{project.title}</h3>
+                      <p className={styles.projectDate}>
+                        {formatDateRange(project.startDate, project.endDate ?? undefined)}
+                      </p>
+                    </div>
 
-                  <div className={styles.projectStatus}>
-                    <span className={clsx(styles.statusBadge, styles[`status-${project.status}`])}>
-                      {getStatusText(project.status, 'project')}
-                    </span>
-                  </div>
-                </button>
-              ))}
-            </div>
-
-            {hasMore && (
-              <div className={styles.showMoreContainer}>
-                <button
-                  type="button"
-                  onClick={loadMore}
-                  disabled={isLoading}
-                  className={styles.showMoreButton}
-                >
-                  {getShowMoreText()}
-                </button>
+                    <div className={styles.projectStatus}>
+                      <span
+                        className={clsx(styles.statusBadge, styles[`status-${project.status}`])}
+                      >
+                        {getStatusText(project.status, 'project')}
+                      </span>
+                    </div>
+                  </button>
+                ))}
               </div>
-            )}
-          </>
-        ) : (
-          <div>
-            <p>참여한 프로젝트가 없습니다.</p>
-          </div>
-        )}
-      </div>
-    </section>
-  );
-});
+
+              {hasMore && (
+                <div className={styles.showMoreContainer}>
+                  <button
+                    type="button"
+                    onClick={loadMore}
+                    disabled={isLoading}
+                    className={styles.showMoreButton}
+                  >
+                    {getShowMoreText()}
+                  </button>
+                </div>
+              )}
+            </>
+          ) : (
+            <div>
+              <p>참여한 프로젝트가 없습니다.</p>
+            </div>
+          )}
+
+          {/* 비공개 메시지 */}
+          {isPrivate && (
+            <div className={styles.privateMessage}>
+              <LockIcon size={16} weight="regular" />
+              <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
+            </div>
+          )}
+        </div>
+      </section>
+    );
+  }
+);
 
 ProjectSection.displayName = 'ProjectSection';
 export default ProjectSection;

--- a/src/features/Profile/components/sections/StudySection.module.scss
+++ b/src/features/Profile/components/sections/StudySection.module.scss
@@ -199,3 +199,22 @@
     padding: 6px 12px;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/StudySection.tsx
+++ b/src/features/Profile/components/sections/StudySection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { BookBookmarkIcon } from '@phosphor-icons/react';
+import { BookBookmarkIcon, LockIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 
@@ -18,97 +18,109 @@ interface StudySectionProps extends ProfileSectionProps {
   className?: string;
 }
 
-const StudySection = forwardRef<HTMLElement, StudySectionProps>(({ user, className }, ref) => {
-  const navigate = useNavigate();
-  const initialStudies = user.studies || [];
-  const {
-    items: studies,
-    isLoading,
-    hasMore,
-    loadMore,
-    getShowMoreText,
-  } = useInfiniteLoad(user.userId, 'studies', initialStudies, user.studiesTotalItems);
+const StudySection = forwardRef<HTMLElement, StudySectionProps>(
+  ({ user, isPrivate = false, className }, ref) => {
+    const navigate = useNavigate();
+    const initialStudies = user.studies || [];
+    const {
+      items: studies,
+      isLoading,
+      hasMore,
+      loadMore,
+      getShowMoreText,
+    } = useInfiniteLoad(user.userId, 'studies', initialStudies, user.studiesTotalItems);
 
-  const handleStudyClick = (studyId: number, teamId: number) => {
-    if (user.isMine) {
-      // 본인 프로필: 팀관리 페이지로 이동
-      navigate(`/team/${teamId}/setting`);
-    } else {
-      // 타인 프로필: 스터디 모집 공고 페이지로 이동
-      navigate(`/detail/study/${studyId}`);
-    }
-  };
+    const handleStudyClick = (studyId: number, teamId: number) => {
+      if (user.isMine) {
+        // 본인 프로필: 팀관리 페이지로 이동
+        navigate(`/team/${teamId}/setting`);
+      } else {
+        // 타인 프로필: 스터디 모집 공고 페이지로 이동
+        navigate(`/detail/study/${studyId}`);
+      }
+    };
 
-  const getAriaLabel = (title: string) => {
-    return user.isMine ? `${title} 스터디 팀 관리 페이지로 이동` : `${title} 스터디 모집 공고 보기`;
-  };
+    const getAriaLabel = (title: string) => {
+      return user.isMine
+        ? `${title} 스터디 팀 관리 페이지로 이동`
+        : `${title} 스터디 모집 공고 보기`;
+    };
 
-  return (
-    <section
-      ref={ref}
-      className={clsx(styles.studySection, className)}
-      aria-labelledby="study-title"
-    >
-      <div className={styles.header}>
-        <h2 id="study-title" className={styles.title}>
-          스터디
-        </h2>
-      </div>
+    return (
+      <section
+        ref={ref}
+        className={clsx(styles.studySection, className)}
+        aria-labelledby="study-title"
+      >
+        <div className={styles.header}>
+          <h2 id="study-title" className={styles.title}>
+            스터디
+          </h2>
+        </div>
 
-      <div>
-        {studies.length > 0 ? (
-          <>
-            <div className={styles.studyList}>
-              {studies.map(study => (
-                <button
-                  key={study.id}
-                  type="button"
-                  className={styles.studyItem}
-                  onClick={() => handleStudyClick(study.id, study.teamId)}
-                  aria-label={getAriaLabel(study.title)}
-                >
-                  <div className={styles.studyIcon}>
-                    <BookBookmarkIcon size={21} weight="regular" />
-                  </div>
+        <div>
+          {studies.length > 0 ? (
+            <>
+              <div className={styles.studyList}>
+                {studies.map(study => (
+                  <button
+                    key={study.id}
+                    type="button"
+                    className={styles.studyItem}
+                    onClick={() => handleStudyClick(study.id, study.teamId)}
+                    aria-label={getAriaLabel(study.title)}
+                  >
+                    <div className={styles.studyIcon}>
+                      <BookBookmarkIcon size={21} weight="regular" />
+                    </div>
 
-                  <div className={styles.studyInfo}>
-                    <h3 className={styles.studyTitle}>{study.title}</h3>
-                    <p className={styles.studyDate}>
-                      {formatDateRange(study.startDate, study.endDate ?? undefined)}
-                    </p>
-                  </div>
+                    <div className={styles.studyInfo}>
+                      <h3 className={styles.studyTitle}>{study.title}</h3>
+                      <p className={styles.studyDate}>
+                        {formatDateRange(study.startDate, study.endDate ?? undefined)}
+                      </p>
+                    </div>
 
-                  <div className={styles.studyStatus}>
-                    <span className={clsx(styles.statusBadge, styles[`status-${study.status}`])}>
-                      {getStatusText(study.status, 'study')}
-                    </span>
-                  </div>
-                </button>
-              ))}
-            </div>
-
-            {hasMore && (
-              <div className={styles.showMoreContainer}>
-                <button
-                  type="button"
-                  onClick={loadMore}
-                  disabled={isLoading}
-                  className={styles.showMoreButton}
-                >
-                  {getShowMoreText()}
-                </button>
+                    <div className={styles.studyStatus}>
+                      <span className={clsx(styles.statusBadge, styles[`status-${study.status}`])}>
+                        {getStatusText(study.status, 'study')}
+                      </span>
+                    </div>
+                  </button>
+                ))}
               </div>
-            )}
-          </>
-        ) : (
-          <div>
-            <p>참여한 스터디가 없습니다.</p>
+
+              {hasMore && (
+                <div className={styles.showMoreContainer}>
+                  <button
+                    type="button"
+                    onClick={loadMore}
+                    disabled={isLoading}
+                    className={styles.showMoreButton}
+                  >
+                    {getShowMoreText()}
+                  </button>
+                </div>
+              )}
+            </>
+          ) : (
+            <div>
+              <p>참여한 스터디가 없습니다.</p>
+            </div>
+          )}
+        </div>
+
+        {/* 비공개 메시지 */}
+        {isPrivate && (
+          <div className={styles.privateMessage}>
+            <LockIcon size={16} weight="regular" />
+            <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
           </div>
         )}
-      </div>
-    </section>
-  );
-});
+      </section>
+    );
+  }
+);
 
 StudySection.displayName = 'StudySection';
 export default StudySection;

--- a/src/features/Profile/components/sections/TechStackSection.module.scss
+++ b/src/features/Profile/components/sections/TechStackSection.module.scss
@@ -132,3 +132,22 @@
     padding: 6px 12px;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/TechStackSection.tsx
+++ b/src/features/Profile/components/sections/TechStackSection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { PencilSimpleIcon } from '@phosphor-icons/react';
+import { LockIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 
 import type { ProfileSectionProps } from '@/types/user';
@@ -17,7 +17,7 @@ interface TechStackSectionProps extends ProfileSectionProps {
 }
 
 const TechStackSection = forwardRef<HTMLElement, TechStackSectionProps>(
-  ({ user, isEditable = false, onEdit, className }, ref) => {
+  ({ user, isEditable = false, onEdit, isPrivate = false, className }, ref) => {
     const { items, isLoading, hasMore, loadMore, getShowMoreText } = useInfiniteTechStacks(
       user.userId,
       user.techStacks || [],
@@ -83,6 +83,14 @@ const TechStackSection = forwardRef<HTMLElement, TechStackSectionProps>(
             </div>
           )}
         </div>
+
+        {/* 비공개 메시지 */}
+        {isPrivate && (
+          <div className={styles.privateMessage}>
+            <LockIcon size={16} weight="regular" />
+            <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
+          </div>
+        )}
       </section>
     );
   }

--- a/src/features/Profile/components/sections/TimeSection.module.scss
+++ b/src/features/Profile/components/sections/TimeSection.module.scss
@@ -97,3 +97,22 @@
     @include m.font-tiny-text;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/TimeSection.tsx
+++ b/src/features/Profile/components/sections/TimeSection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { PencilSimpleIcon } from '@phosphor-icons/react';
+import { LockIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 
 import type { ProfileSectionProps } from '@/types/user';
@@ -17,7 +17,7 @@ interface TimeSectionProps extends ProfileSectionProps {
 }
 
 const TimeSection = forwardRef<HTMLElement, TimeSectionProps>(
-  ({ user, isEditable = false, onEdit, className }, ref) => {
+  ({ user, isEditable = false, onEdit, isPrivate = false, className }, ref) => {
     const handleEdit = () => {
       if (isEditable && onEdit) {
         onEdit('time');
@@ -59,6 +59,14 @@ const TimeSection = forwardRef<HTMLElement, TimeSectionProps>(
             <span className={styles.timeRange}>{getTimeRange()}</span>
           </div>
         </div>
+
+        {/* 비공개 메시지 */}
+        {isPrivate && (
+          <div className={styles.privateMessage}>
+            <LockIcon size={16} weight="regular" />
+            <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
+          </div>
+        )}
       </section>
     );
   }

--- a/src/features/Profile/components/sections/TraitsSection.module.scss
+++ b/src/features/Profile/components/sections/TraitsSection.module.scss
@@ -86,3 +86,22 @@
     padding: 2px 10px;
   }
 }
+
+.privateMessage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 17px 12px 0;
+  border-top: 1px solid v.$gray-4;
+  font-size: v.$fs-xxxsmall;
+  text-align: center;
+  color: v.$gray-1;
+
+  @include m.mobile {
+    margin-top: 12px;
+    padding: 13px 8px 0;
+    font-size: 11px;
+  }
+}

--- a/src/features/Profile/components/sections/TraitsSection.tsx
+++ b/src/features/Profile/components/sections/TraitsSection.tsx
@@ -3,7 +3,7 @@
 
 import { forwardRef } from 'react';
 
-import { PencilSimpleIcon } from '@phosphor-icons/react';
+import { LockIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import clsx from 'clsx';
 
 import type { ProfileSectionProps } from '@/types/user';
@@ -15,7 +15,7 @@ interface TraitsSectionProps extends ProfileSectionProps {
 }
 
 const TraitsSection = forwardRef<HTMLElement, TraitsSectionProps>(
-  ({ user, isEditable = false, onEdit, className }, ref) => {
+  ({ user, isEditable = false, onEdit, isPrivate = false, className }, ref) => {
     const handleEdit = () => {
       if (isEditable && onEdit) {
         onEdit('traits');
@@ -62,6 +62,14 @@ const TraitsSection = forwardRef<HTMLElement, TraitsSectionProps>(
             </div>
           )}
         </div>
+
+        {/* 비공개 메시지 */}
+        {isPrivate && (
+          <div className={styles.privateMessage}>
+            <LockIcon size={16} weight="regular" />
+            <span>프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.</span>
+          </div>
+        )}
       </section>
     );
   }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -190,4 +190,5 @@ export interface ProfileSectionProps {
   user: CompleteProfileInfo;
   isEditable?: boolean;
   onEdit?: (sectionType: ProfileSectionType) => void;
+  isPrivate?: boolean; // 비공개 상태 표시를 위한 prop
 }


### PR DESCRIPTION

---

## 📌 작업 내용 요약
<img width="1920" height="967" alt="스크린샷 2025-09-16 오후 12 20 35" src="https://github.com/user-attachments/assets/f8377caf-09a0-4c05-9d1c-c8466ba8ddb2" />
`프로필 비공개 중입니다. 다른 사용자에게는 보이지 않습니다.`라는 멘트를 추가해주엇슴니다

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #211 

